### PR TITLE
Table tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,6 @@
 all:
 	cd benchmarks && ${MAKE}
+
+bench:
+	env PYPY_PREFIX=`pwd`/work/pyhyp/pypy-hippy-bridge \
+		python2.7 runner.py config.py

--- a/ascii_table.py
+++ b/ascii_table.py
@@ -1,0 +1,137 @@
+#! work/virtualenv/pypy/bin/pypy
+# A quick script which generates confidence intervals for rough benchmarking
+# Used during VM optimisation to get a rough idea if a change helped.
+
+import sys
+import json
+import math
+import prettytable
+import os
+
+from pykalibera.data import Data
+
+CONF_SIZE = "0.99"  # intentionally str
+
+try:
+    debug = os.environ["TABLE_DEBUG"]
+    ITERATIONS = 1
+except KeyError:
+    ITERATIONS = 10000
+
+
+def dot():
+    sys.stdout.write(".")
+    sys.stdout.flush()
+
+
+def avg(seq):
+    return math.fsum(seq) / len(seq)
+
+
+def error(data):
+    # lower, median, upper
+    a, b, c = data.bootstrap_confidence_interval(
+        ITERATIONS,
+        confidence=CONF_SIZE)
+
+    return avg([b - a, c - b])
+
+
+def make_kalibera_data(exp_data, warmup):
+    data_arg = {}
+    total_execs = len(exp_data)
+    for exec_n in range(total_execs):
+        exec_nowarmup = exp_data[exec_n][warmup - 1:]
+        if not exec_nowarmup:
+            return None
+        data_arg[(exec_n, )] = exec_nowarmup
+
+    return Data(data_arg, [total_execs, len(data_arg[(0, )])])
+
+
+class ResultInfo(object):
+    def __init__(self, val, val_err, warmup):
+        self.val, self.val_err = val, val_err
+        self.warmup = warmup
+
+    @classmethod
+    def missing(cls, warmup):
+        return cls(None, None, warmup)
+
+
+def make_tables(config, data_file):
+    with open(data_file, "r") as data_fh:
+        results = json.load(data_fh)["data"]
+
+    row_data = {}
+    for vm_key, vm_data in sorted(config.VMS.iteritems()):
+        for bench_key, bench_data in sorted(config.BENCHMARKS.iteritems()):
+            dot()
+            variants = vm_data["variants"]
+
+            for variant_key in variants:
+                warmup = vm_data["warm_upon_iter"]
+
+                rs_key = "%s:%s:%s" % (bench_key, vm_key, variant_key)
+                try:
+                    rs = results[rs_key]
+                except KeyError:
+                    row_data[rs_key] = ResultInfo.missing(warmup)
+                    continue
+
+                # Absolute
+                kdata = make_kalibera_data(rs, warmup)
+                if kdata is None:
+                    # not enough data to be useful
+                    row_data[rs_key] = ResultInfo.missing(warmup)
+                    continue
+
+                val = kdata.mean()
+                val_err = error(kdata)
+
+                ri = ResultInfo(val, val_err, warmup)
+                row_data[rs_key] = ri
+    print("")
+    make_ascii_table(row_data)
+
+
+def make_ascii_table(row_data):
+    tb = prettytable.PrettyTable(
+        ["Benchmark", "VM", "Variant", "Seconds", "Error"])
+    tb.align["Benchmark"] = "l"
+    tb.align["WarmIter"] = "r"
+    tb.align["Seconds"] = "r"
+    tb.align["Error"] = "r"
+    tb.float_format = "4.6"
+
+    for k, v in row_data.iteritems():
+        bench, vm, variant = k.split(":")
+        tb.add_row([bench, "%s (warm=%d)" % (vm, v.warmup),
+                   variant, v.val, v.val_err])
+
+    sys.stdout.write("\n")
+    print(tb.get_string(sortby="Benchmark"))
+
+
+def usage():
+    print("usage: %s <config-file>" % __file__)
+    sys.exit(1)
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        usage()
+
+    try:
+        config_file = sys.argv[1]
+    except KeyError:
+        usage()
+
+    import_name = config_file[:-3]
+    data_file = import_name + "_results.json"
+    try:
+        config = __import__(import_name)
+    except:
+        print("*** error importing config file!\n")
+        raise
+
+    make_tables(config, data_file)


### PR DESCRIPTION
This PR:
- Moves support for drawing ASCII tables out of the (more complicated) latex table script.
- Adds support for showing the new "reverse composed" benchmarks.
- Adds a new table (or rather grid) for deltablue permutations.
- Tidies up the code a lot.

Someone who understands the number crunching behind kalibera method needs to review this code carefully. Perhaps @cfbolz?

I want to rename `confidence.py` to `latex_table.py`, but I will do that last before merge, so the "changed files" tab on GH makes sense.

I'm attaching a rough PDF of the results from our 1x15 run on bencher5. All warmups were set (arbitrarily) to 6. I'm not yet worrying about the numbers at this point -- I'm thinking solely about formatting and correctness of the number crunching. Later I will properly look at numbers and optimise/dimension properly.

The first two tables have a new column _PyHyp_c'_ (primed) which shows the results for the the composed benchmarks in the opposite direction to _PyHyp_c_. Blanks cells correspond to benchmarks which, in the standard composed variant, use `compile_py_meth()`. These benchmarks can't be run in the opposite direction as we can't yet embed PHP methods into Python classes. In other words we have no `compile_php_meth()` yet.

The second table, is showing the results for _PyHyp_c'_ relative to _PyHyp_c_, which arguably isn't much help, as we probably want to see the _PyPy_ and _Hippy_ results relative to _PyHyp_c'_. This would require another table, which, based on a conversation with @ltratt about paper real-estate, we might not have space for. Thoughts and suggestions welcome.

The third (new) table (or rather grid) shows the absolute and relative times of the deltablue permutations. Each cell shows the results for one permutation. The relative readings are relative to PyHyp running a mono-php version of deltablue. This should give us insight into which Python functions/methods impose the most/lest overhead. The grid you see it about the 3rd attempt at putting as much information into as little space as possible. What do you think?

CC @ltratt, @cfbolz.
[main.pdf](https://github.com/softdevteam/pyhyp_experiments/files/33996/main.pdf)
